### PR TITLE
feature: Add email templates for metrics addition, recalculation and deprecation

### DIFF
--- a/src/assets/scss/template/_elements.scss
+++ b/src/assets/scss/template/_elements.scss
@@ -6,6 +6,16 @@
   margin: 0 !important;
 }
 
+.px-32 {
+  padding-left: 32px;
+  padding-right: 32px;
+}
+
+.py-24 {
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+
 .pr-24 {
   padding-right: 24px;
 }

--- a/src/assets/scss/template/_template.scss
+++ b/src/assets/scss/template/_template.scss
@@ -237,7 +237,7 @@ a {
   border-bottom: 1px solid #E7EAF3;
 }
 
-.item-desc{
+.item-desc {
   font-size: 14px;
   margin-bottom: 4px;
 }
@@ -271,11 +271,13 @@ table.footer .footer-mb {
   white-space: pre-line;
 }
 
-.footer a, .footer a .small {
+.footer a,
+.footer a .small {
   border-bottom: none;
 }
 
-.footer a .small, .underline{
+.footer a .small,
+.underline {
   border-bottom: 1px solid #7A859E;
 }
 
@@ -342,7 +344,12 @@ table.footer .footer-mb {
 
 .jungleinfobox {
   background: #EDF8F5;
-  border-radius: 8px;  
+  border-radius: 8px;
+}
+
+.greyinfobox {
+  background: #F3F4FA;
+  border-radius: 8px;
 }
 
 .infotd {
@@ -480,38 +487,39 @@ table.footer .footer-mb {
 
 @media (max-width:#{$global-breakpoint}) {
   .small {
-		font-size: 80% !important;
-	}
+    font-size: 80% !important;
+  }
 
   .hidemobile {
-      display: none !important;
+    display: none !important;
   }
 
   .showmobile {
-      display: block !important;
+    display: block !important;
   }
 
   .container {
-      padding-left: 16px !important;
-      padding-right: 16px !important;
+    padding-left: 16px !important;
+    padding-right: 16px !important;
   }
 
-  table.body .collapse > tbody > tr > .columns, table.body .collapse > tbody > tr > .column {
+  table.body .collapse>tbody>tr>.columns,
+  table.body .collapse>tbody>tr>.column {
     padding: 0 !important;
   }
 
   table.button table td a {
-      display: block !important;
-      text-align: center !important;
-      font-weight: 500 !important;
-      font-size: 18px !important;
-      padding: 12px 20px !important;
+    display: block !important;
+    text-align: center !important;
+    font-weight: 500 !important;
+    font-size: 18px !important;
+    padding: 12px 20px !important;
   }
 
   .footer .radius {
     padding: 40px 24px !important;
   }
-  
+
   .footer .footer-logo {
     margin-bottom: 24px !important;
   }
@@ -537,11 +545,11 @@ table.footer .footer-mb {
   }
 
   img.mail-list-check {
-      height: 21px !important;
+    height: 21px !important;
   }
 
   .mail-list span {
-      max-width: 400px !important;
+    max-width: 400px !important;
   }
 
   .socials th {
@@ -620,7 +628,10 @@ table.footer .footer-mb {
     margin-bottom: 32px !important;
   }
 
-  .footer, .footer p, .footer td, .footer th {
+  .footer,
+  .footer p,
+  .footer td,
+  .footer th {
     font-size: 16px !important;
     line-height: 24px !important;
   }

--- a/src/pages/metrics-added.html
+++ b/src/pages/metrics-added.html
@@ -1,0 +1,37 @@
+---
+layout: mail-layout
+image-url: https://api.santiment.net/images/emails/
+---
+
+<container class="radius">
+  <row class="collapse">
+    <columns small="12">
+      <h2 class="h2">New Metrics Added</h2>
+
+      <spacer size="8"></spacer>
+
+      <img
+        src="https://production-sanbase-images.s3.amazonaws.com/uploads/b8381cd1dd9309ba98b37bae3c61c948a3eaa3cee7a803eccab65dcdab81ac19_1738670623481_metrics-added.png">
+
+      <spacer size="40"></spacer>
+
+      <p class="jungleinfobox px-32 py-24">
+        Exciting news! The latest update has introduced new metrics: {{{{raw}}}}{{var:metrics_list}}{{{{/raw}}}}. For
+        detailed information, please
+        visit our changelog.
+      </p>
+
+      <spacer size="28"></spacer>
+
+      <button class="radius" href="https://academy.santiment.net/changelog/" target="_blank">
+        <span>Check Changelog</span>
+      </button>
+
+      <spacer size="48"></spacer>
+
+      {{> regards}}
+    </columns>
+  </row>
+</container>
+
+{{> mail-footer-auto}}

--- a/src/pages/metrics-deprecation.html
+++ b/src/pages/metrics-deprecation.html
@@ -1,0 +1,37 @@
+---
+layout: mail-layout
+image-url: https://api.santiment.net/images/emails/
+---
+
+<container class="radius">
+  <row class="collapse">
+    <columns small="12">
+      <h2 class="h2">Metrics Deprecation Planned</h2>
+
+      <spacer size="8"></spacer>
+
+      <img
+        src="https://production-sanbase-images.s3.amazonaws.com/uploads/5c8dcf4d00db4f1141e99244260c70879b776ccd584903ff664a1d38eb5d9a10_1738671627780_metrics-deprecation.png">
+
+      <spacer size="40"></spacer>
+
+      <p class="greyinfobox px-32 py-24">
+        As part of our efforts to optimize our offerings, we have decided to deprecate the following metrics due to low
+        usage: {{{{raw}}}}{{var:metrics_list}}{{{{/raw}}}}. This change is scheduled to occur on
+        {{{{raw}}}}{{var:scheduled_at}}{{{{/raw}}}}.
+      </p>
+
+      <spacer size="28"></spacer>
+
+      <button class="radius" href="https://academy.santiment.net/changelog/" target="_blank">
+        <span>Check Changelog</span>
+      </button>
+
+      <spacer size="48"></spacer>
+
+      {{> regards}}
+    </columns>
+  </row>
+</container>
+
+{{> mail-footer-auto}}

--- a/src/pages/metrics-recalculation.html
+++ b/src/pages/metrics-recalculation.html
@@ -1,0 +1,38 @@
+---
+layout: mail-layout
+image-url: https://api.santiment.net/images/emails/
+---
+
+<container class="radius">
+  <row class="collapse">
+    <columns small="12">
+      <h2 class="h2">Metrics Recalculation Scheduled</h2>
+
+      <spacer size="8"></spacer>
+
+      <img
+        src="https://production-sanbase-images.s3.amazonaws.com/uploads/e196f2e9854e2e0930975dd82a993cdb4525acbf3b1ab2e82cc6987bfb013524_1738671375982_metrics-recalculation.png">
+
+      <spacer size="40"></spacer>
+
+      <p class="suninfobox px-32 py-24">
+        To enhance the accuracy of our data, we will be recalculating the following metrics:
+        {{{{raw}}}}{{var:metrics_list}}{{{{/raw}}}}. This recalculation is scheduled for
+        {{{{raw}}}}{{var:scheduled_at}}{{{{/raw}}}} and is expected to take approximately
+        {{{{raw}}}}{{var:duration}}{{{{/raw}}}}.
+      </p>
+
+      <spacer size="28"></spacer>
+
+      <button class="radius" href="https://academy.santiment.net/changelog/" target="_blank">
+        <span>Check Changelog</span>
+      </button>
+
+      <spacer size="48"></spacer>
+
+      {{> regards}}
+    </columns>
+  </row>
+</container>
+
+{{> mail-footer-auto}}


### PR DESCRIPTION
## Summary

Add email templates for metrics addition, recalculation and deprecation notifications

## Notion card
https://www.notion.so/santiment/Add-email-templates-for-notification-system-18f2a82d13618052b497f644274d9c46?pvs=4

## Screenshots
![image](https://github.com/user-attachments/assets/c67500b7-bf02-44ee-93dd-a2c715b85cb2)

![image](https://github.com/user-attachments/assets/f3c46506-8bba-41ac-96d3-8ea0d8f2b193)

![image](https://github.com/user-attachments/assets/920b7a26-5b6b-4aa3-a3f1-b2afb50c0bd2)
